### PR TITLE
cleanup temp files on ffmpeg errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -519,11 +519,13 @@ func handleConvert(ctx context.Context, url, profile, start, end, outDir string)
 			} else {
 				errMsg := fmt.Sprintf("ffmpeg falhou.\n---LOG 1 (com corte)---\n%s\n---LOG 2 (sem corte)---\n%s", log, log2)
 				setStage("Erro", errMsg, false)
+				cleanupConvertTemp(tempDir, tempPattern, outFile)
 				return "", fmt.Errorf(errMsg)
 			}
 		}
 		errMsg := fmt.Sprintf("ffmpeg falhou:\n%s", log)
 		setStage("Erro", errMsg, false)
+		cleanupConvertTemp(tempDir, tempPattern, outFile)
 		return "", fmt.Errorf(errMsg)
 	}
 


### PR DESCRIPTION
## Summary
- ensure cleanupConvertTemp is called when ffmpeg conversion fails
- remove temp files, temp dir, and partial output on ffmpeg error

## Testing
- `gofmt -w main.go`
- `go build -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6671b0774832cae4f311b11ee08e7