### PR TITLE
feat: make server address configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -641,16 +642,18 @@ func main() {
 		return
 	}
 
+	addr := flag.String("addr", "127.0.0.1:8080", "endereço do servidor")
+	flag.Parse()
+
 	http.HandleFunc("/", indexHandler)
 	http.HandleFunc("/action", actionHandler)
 	http.HandleFunc("/status", statusHandler)
 	http.HandleFunc("/pick-folder", pickFolderHandler)
 	http.HandleFunc("/cancel", cancelHandler)
 
-	addr := ":8080"
-	go openBrowser("http://localhost" + addr)
-	fmt.Println("🚀 Servidor rodando em http://localhost" + addr)
-	if err := http.ListenAndServe(addr, nil); err != nil {
+	go openBrowser("http://" + *addr)
+	fmt.Println("🚀 Servidor rodando em http://" + *addr)
+	if err := http.ListenAndServe(*addr, nil); err != nil {
 		fmt.Println("Erro no servidor:", err)
 	}
 }


### PR DESCRIPTION
## Summary
- allow configuring server address with `-addr` flag (default `127.0.0.1:8080`)
- update browser launch and logs to use configured address

## Testing
- `go test ./...`
- `go vet ./...` *(warning: json.NewEncoder(w).Encode copies lock value: VideoCutterApp.appStatus contains sync.Mutex)*


------
https://chatgpt.com/codex/tasks/task_e_68a66712d120832ca01db152333c7b79