### PR TITLE
Improve index handler error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -26,9 +27,17 @@ var content embed.FS
 
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path == "/" {
-		data, _ := content.ReadFile("web/index.html")
+		data, err := content.ReadFile("web/index.html")
+		if err != nil {
+			log.Printf("erro ao ler index.html: %v", err)
+			http.Error(w, "Erro ao carregar página", http.StatusInternalServerError)
+			return
+		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = w.Write(data)
+		if _, err := w.Write(data); err != nil {
+			log.Printf("erro ao escrever resposta: %v", err)
+			return
+		}
 		return
 	}
 	http.FileServer(http.FS(content)).ServeHTTP(w, r)


### PR DESCRIPTION
## Summary
- log and return HTTP 500 when `index.html` fails to load
- log write failures when serving index page

## Testing
- `gofmt -w main.go`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6670f6e54832c88f9c5907cef31b0