### PR TITLE
fix: decode folder picker output reliably

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"embed"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -20,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf16"
 )
 
 // ------------------- EMBED FRONTEND -------------------
@@ -284,6 +286,19 @@ func sanitizeFilename(name string) string {
 		name = name[:150]
 	}
 	return name
+}
+
+// hasInvalidPathRune reports whether s contains control characters or symbols
+// that are invalid in Windows file paths.
+func hasInvalidPathRune(s string) bool {
+	for i, r := range s {
+		if r < 32 || strings.ContainsRune(`<>:"|?*`, r) {
+			if !(i == 1 && r == ':') {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func getVideoTitle(ctx context.Context, url string) (string, error) {
@@ -591,7 +606,43 @@ func pickFolderHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Falha ao abrir seletor de pasta: "+out.String(), http.StatusInternalServerError)
 		return
 	}
-	path := strings.TrimSpace(out.String())
+
+	raw := out.Bytes()
+	var path string
+	switch {
+	case len(raw) >= 2 && raw[0] == 0xFF && raw[1] == 0xFE:
+		// UTF-16LE with BOM
+		raw = raw[2:]
+		u16 := make([]uint16, 0, len(raw)/2)
+		for i := 0; i+1 < len(raw); i += 2 {
+			u16 = append(u16, binary.LittleEndian.Uint16(raw[i:i+2]))
+		}
+		path = string(utf16.Decode(u16))
+	case len(raw) >= 2 && raw[0] == 0xFE && raw[1] == 0xFF:
+		// UTF-16BE with BOM
+		raw = raw[2:]
+		u16 := make([]uint16, 0, len(raw)/2)
+		for i := 0; i+1 < len(raw); i += 2 {
+			u16 = append(u16, binary.BigEndian.Uint16(raw[i:i+2]))
+		}
+		path = string(utf16.Decode(u16))
+	case bytes.IndexByte(raw, 0) != -1:
+		// UTF-16 without BOM (assume little-endian)
+		u16 := make([]uint16, 0, len(raw)/2)
+		for i := 0; i+1 < len(raw); i += 2 {
+			u16 = append(u16, binary.LittleEndian.Uint16(raw[i:i+2]))
+		}
+		path = string(utf16.Decode(u16))
+	default:
+		// assume UTF-8
+		path = string(raw)
+	}
+	path = strings.TrimSpace(strings.Trim(path, "\x00"))
+	if strings.ContainsRune(path, '\uFFFD') || hasInvalidPathRune(path) {
+		http.Error(w, "Caminho de destino contém caracteres inválidos.", http.StatusBadRequest)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(pickFolderResp{Path: path})
 }


### PR DESCRIPTION
## Summary
- handle UTF-16LE/BE and UTF-8 outputs from Windows folder picker
- trim NUL and whitespace characters from selected path
- reject destination paths containing invalid characters

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a66f12a654832c9efddbad9639abe1